### PR TITLE
Use escapeshellcmd

### DIFF
--- a/dl.php
+++ b/dl.php
@@ -1,5 +1,5 @@
 <?php
-$ytid=$_GET['ytid']; //here you have to add some security features to prevent injections. maybe with escapeshellcmd (
+$ytid=escapeshellcmd($_GET['ytid']);
 header("Content-Type: application/octet-stream");
 header("Content-Disposition: attachment; filename=\"Youtube_$ytid.mp3\"");#maybe add the youtube title...
 passthru("youtube-dl -o - '$ytid' | ffmpeg -i - -f mp3 - -codec:a libmp3lame -b:a 320k");


### PR DESCRIPTION
escapeshellcmd is the correct function for preventing command-line injections.  You may also want to use urlencode() if you want to limit to only youtube.com, and not allow other video sites.
